### PR TITLE
Fix object instantiation bug

### DIFF
--- a/src/asset.cpp
+++ b/src/asset.cpp
@@ -1,6 +1,11 @@
 #include "asset.hpp"
 #include <exception>
 
+Network Network::mainnet {"mainnet"};
+Network Network::testnet {"testnet"};
+std::vector<Network> Network::_networks = {
+    mainnet, testnet
+};
 Asset Asset::btc = {"Bitcoin", "btc", Network::mainnet, 0, 0x00, 0x05};
 Asset Asset::btct = {"Bitcoin Testnet", "btct", Network::testnet, 1, 0x6f, 0xc4};
 

--- a/src/asset.cpp
+++ b/src/asset.cpp
@@ -1,17 +1,25 @@
 #include "asset.hpp"
 #include <exception>
+#include <assert.h>
 
-Network Network::mainnet {"mainnet"};
-Network Network::testnet {"testnet"};
-std::vector<Network> Network::_networks = {
-    mainnet, testnet
-};
-Asset Asset::btc = {"Bitcoin", "btc", Network::mainnet, 0, 0x00, 0x05};
-Asset Asset::btct = {"Bitcoin Testnet", "btct", Network::testnet, 1, 0x6f, 0xc4};
+const Asset *Asset::btc = NULL;
+const Asset *Asset::btct = NULL;
+std::vector<Asset> *Asset::_assets = NULL;
 
-std::vector<Asset> Asset::_assets = {
-    btc, btct
-};
+// construct static members at run-time as they depend on objects from another scope
+void Asset::init(void) {
+    static const Asset _btc = {"Bitcoin", "btc", Network::mainnet, 0, 0x00, 0x05};
+    static const Asset _btct = {"Bitcoin Testnet", "btct", Network::testnet, 1, 0x6f, 0xc4};
+
+    btc = &_btc;
+    btct = &_btct;
+
+    assert(_assets == NULL);
+
+    _assets = new std::vector<Asset>;
+    _assets->push_back(*btc);
+    _assets->push_back(*btct);
+}
 
 std::ostream& operator<< (std::ostream& os, const Asset& asset) {
     return os << asset.symbol();

--- a/src/asset.hpp
+++ b/src/asset.hpp
@@ -24,9 +24,10 @@ public:
     uint8_t version_pkh() const { return _version_pkh; }
     uint8_t version_sh() const { return _version_sh; }
 
-    static Asset btc;
-    static Asset btct;
-    static const std::vector<Asset>& assets() { return _assets; }
+    static void init(void);
+    static const Asset *btc;
+    static const Asset *btct;
+    static const std::vector<Asset>& assets() { return _assets ? *_assets : throw std::runtime_error("_assets NULL"); }
     static Asset find(const std::string& symbol);
 
 private:
@@ -37,7 +38,7 @@ private:
     uint8_t _version_pkh;
     uint8_t _version_sh;
 
-    static std::vector<Asset> _assets;
+    static std::vector<Asset> *_assets;
 };
 
 std::ostream& operator<< (std::ostream& os, const Asset& asset);

--- a/src/keytool.cpp
+++ b/src/keytool.cpp
@@ -13,6 +13,9 @@
 using namespace std;
 
 int main( int argc, char *argv[] ) {
+
+    Asset::init();
+
     try {
         auto p = Params::parse(argc, argv);
         p->process();

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -44,7 +44,7 @@ Model::Model()
     all_nodes.push_back(&seed);
 
     // asset
-    asset = Asset::btc;
+    asset = Asset::btc ? *Asset::btc : throw runtime_error("Asset::btc NULL");
     asset.set_to_string([](const Asset& asset) { return asset.symbol(); });
     asset.set_from_string([](const string& symbol) -> Asset { return Asset::find(symbol); });
     all_nodes.push_back(&asset);

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -1,5 +1,12 @@
 #include "asset.hpp"
 
+Network Network::mainnet {"mainnet"};
+Network Network::testnet {"testnet"};
+
+std::vector<Network> Network::_networks = {
+    mainnet, testnet
+};
+
 std::ostream& operator<< (std::ostream& os, const Network& network) {
     return os << network.name();
 }

--- a/src/network.cpp
+++ b/src/network.cpp
@@ -1,12 +1,5 @@
 #include "asset.hpp"
 
-Network Network::mainnet {"mainnet"};
-Network Network::testnet {"testnet"};
-
-std::vector<Network> Network::_networks = {
-    mainnet, testnet
-};
-
 std::ostream& operator<< (std::ostream& os, const Network& network) {
     return os << network.name();
 }


### PR DESCRIPTION
## Abstract

Fixes #3 

The bug happened due to "race conditions" in object instantiation dependent on another object instantiation.

Linux builds and runs unit tests fine.

Windows builds and runs unit tests fine (ran manually)

## Status

Ready for review