### PR TITLE
Update libwally

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,4 +6,4 @@
 	url = https://github.com/BlockchainCommons/bc-libwally-core.git
 [submodule "deps/bc-crypto-base"]
 	path = deps/bc-crypto-base
-	url = git@github.com:BlockchainCommons/bc-crypto-base.git
+	url = https://github.com/BlockchainCommons/bc-crypto-base.git

--- a/README.md
+++ b/README.md
@@ -115,15 +115,19 @@ a minimum recommended version 10.
 
 #### Build on Ubuntu and Debian
 
+First, install the dependencies:
+
 ```bash
 $ sudo apt-get update
 
-$ apt install lsb-release wget software-properties-common
+$ sudo apt install lsb-release wget software-properties-common
 $ wget https://apt.llvm.org/llvm.sh
 $ chmod +x llvm.sh
 $ sudo ./llvm.sh 10  # version 10
 $ sudo apt-get -y install build-essential pkg-config autoconf libtool shunit2 libc++-10-dev libc++abi-10-dev python
 ```
+
+Then, you can clone and bit this repo:
 
 ```bash
 $ sudo apt-get install git

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ These dependencies are automatically installed as submodules when you run the bu
 ```bash
 $ brew install autoconf automake libtool shunit2
 ```
-
+You must then download or clone this repo. Afterward, cd into the repo directory and:
 ```bash
 $ ./build.sh
 $ sudo make install
@@ -117,14 +117,18 @@ a minimum recommended version 10.
 
 ```bash
 $ sudo apt-get update
-$ sudo apt-get -y install build-essential pkg-config autoconf libtool shunit2 libc++-10-dev libc++abi-10-dev python
 
+$ apt install lsb-release wget software-properties-common
 $ wget https://apt.llvm.org/llvm.sh
 $ chmod +x llvm.sh
 $ sudo ./llvm.sh 10  # version 10
+$ sudo apt-get -y install build-essential pkg-config autoconf libtool shunit2 libc++-10-dev libc++abi-10-dev python
 ```
 
 ```bash
+$ sudo apt-get install git
+$ git clone https://github.com/BlockchainCommons/bc-keytool-cli.git
+$ cd bc-keytool-cli/  
 $ export CC="clang-10" && export CXX="clang++-10" && ./build.sh
 $ sudo make install
 ```

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ First, install the dependencies:
 ```bash
 $ sudo apt-get update
 
-$ sudo apt install lsb-release wget software-properties-common
+$ sudo apt install lsb-release wget software-properties-common git
 $ wget https://apt.llvm.org/llvm.sh
 $ chmod +x llvm.sh
 $ sudo ./llvm.sh 10  # version 10
@@ -130,7 +130,6 @@ $ sudo apt-get -y install build-essential pkg-config autoconf libtool shunit2 li
 Then, you can clone and bit this repo:
 
 ```bash
-$ sudo apt-get install git
 $ git clone https://github.com/BlockchainCommons/bc-keytool-cli.git
 $ cd bc-keytool-cli/  
 $ export CC="clang-10" && export CXX="clang++-10" && ./build.sh


### PR DESCRIPTION
## Abstract

* supercedes #6 (Close #6)
* Fixes libwally-core test reported by @shannona 

```bash
============================================
   libwallycore 0.7.8: src/test-suite.log
============================================

# TOTAL: 5
# PASS:  4
# SKIP:  0
# XFAIL: 0
# FAIL:  1
# XPASS: 0
# ERROR: 0

.. contents:: :depth: 2

FAIL: test_clear
================

Found bip39_mnemonic_to_bytes secret at stack position 519136 and base 0x7f610726f010
7f, 7f, 7f, 7f, 7f, 7f, 7f, 7f, 7f, 7f, 7f, 7f, 7f, 7f, 7f, 7f, 
test_bip39 wally_clear() test failed!
FAIL test_clear (exit status: 1)
```
