### PR TITLE
Add continuous integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,12 @@
+name: ci
+on: [push, pull_request]
+jobs:
+  build-MacOS:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: brew install autoconf automake libtool shunit2 gnu-sed
+    - run: ./build.sh
+    - run: sudo make install
+    - run: make distclean
+

--- a/build.sh
+++ b/build.sh
@@ -1,17 +1,17 @@
 #!/bin/bash
 
+# Terminal colors
+RED=`tput setaf 1`
+GREEN=`tput setaf 2`
+BLUE=`tput setaf 4`
+RESET=`tput sgr0`
+
 set -e
 
 git submodule init
 git submodule update
 
 source set_build_paths.sh
-
-# Terminal colors
-RED=`tput setaf 1`
-GREEN=`tput setaf 2`
-BLUE=`tput setaf 4`
-RESET=`tput sgr0`
 
 echo "${BLUE}== bc-crypto-base ==${RESET}"
 


### PR DESCRIPTION
## Abstract

This PR adds CI to Github actions. For now only on macOS instance (https://github.com/ElementsProject/libwally-core/issues/245)

Tested here: https://github.com/gorazdko/bc-keytool-cli/runs/1403281713?check_suite_focus=true

## Status
 
Ready